### PR TITLE
[Actual PR] Translate ES5 class syntax to ES6 syntax

### DIFF
--- a/starter_code/canvas.js
+++ b/starter_code/canvas.js
@@ -1,32 +1,32 @@
+class HangmanCanvas {
+  constructor(secretWord) {
+    this.ctx = document.getElementById("hangman").getContext("2d");
+  }
+  createBoard() {
 
-function HangmanCanvas(secretWord) {
-  this.ctx = document.getElementById('hangman').getContext('2d');
+  }
+
+  drawLines() {
+
+  }
+
+  writeCorrectLetter(index) {
+
+  }
+
+  writeWrongLetter(letter, errorsLeft) {
+
+  }
+
+  drawHangman(shape) {
+
+  }
+
+  gameOver() {
+
+  }
+
+  winner() {
+
+  }
 }
-
-HangmanCanvas.prototype.createBoard = function () {
-
-};
-
-HangmanCanvas.prototype.drawLines = function () {
-
-};
-
-HangmanCanvas.prototype.writeCorrectLetter = function (index) {
-
-};
-
-HangmanCanvas.prototype.writeWrongLetter = function (letter, errorsLeft) {
-
-};
-
-HangmanCanvas.prototype.drawHangman = function (shape) {
-
-};
-
-HangmanCanvas.prototype.gameOver = function () {
-
-};
-
-HangmanCanvas.prototype.winner = function () {
-
-};

--- a/starter_code/hangman.js
+++ b/starter_code/hangman.js
@@ -1,41 +1,38 @@
 var hangman;
 
-// function Hangman() {
+// class Hangman {
+//   getWord() {
 
+//   }
+
+//   checkIfLetter(keyCode) {
+
+//   }
+
+//   checkClickedLetters(key) {
+
+//   }
+
+//   addCorrectLetter(i) {
+
+//   }
+
+//   addWrongLetter(letter) {
+
+//   }
+
+//   checkGameOver() {
+
+//   }
+
+//   checkWinner() {
+
+//   }
 // }
 
-// Hangman.prototype.getWord = function () {
-
-// };
-
-// Hangman.prototype.checkIfLetter = function (keyCode) {
-
-// };
-
-// Hangman.prototype.checkClickedLetters = function (key) {
-
-// };
-
-// Hangman.prototype.addCorrectLetter = function (i) {
-
-// };
-
-// Hangman.prototype.addWrongLetter = function (letter) {
-
-// };
-
-// Hangman.prototype.checkGameOver = function () {
-
-// };
-
-// Hangman.prototype.checkWinner = function () {
-
-// };
-
-document.getElementById('start-game-button').onclick = function () {
+document.getElementById("start-game-button").onclick = function() {
   hangman = new Hangman();
 };
-
 
 document.onkeydown = function (e) {
 


### PR DESCRIPTION
Our students learned the ES6 class syntax and are unfamiliar with the ES5 way of creating classes. The ES5 way is probably not even found in the wild anymore and should be avoided. This commit will update this exercise to use ES6 classes.